### PR TITLE
msm8952: Move GRALLOC_USAGE_PRIVATE_UNCACHED

### DIFF
--- a/libgralloc/gralloc_priv.h
+++ b/libgralloc/gralloc_priv.h
@@ -55,7 +55,7 @@
 
 /* Set this for allocating uncached memory (using O_DSYNC),
  * cannot be used with noncontiguous heaps */
-#define GRALLOC_USAGE_PRIVATE_UNCACHED        0x02000000
+#define GRALLOC_USAGE_PRIVATE_UNCACHED        0x00000004
 
 /* Buffer content should be displayed on an primary display only */
 #define GRALLOC_USAGE_PRIVATE_INTERNAL_ONLY   0x04000000


### PR DESCRIPTION
* E Gralloc2: buffer descriptor contains invalid usage bits 0x2000000

Test: Video playback fixed.

Change-Id: I49bbd060cf5bcca129d46e6411a96dccda1ace50